### PR TITLE
Implement ghcup-npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+package-lock.json
+
 # Logs
 logs
 *.log

--- a/ghcup.js
+++ b/ghcup.js
@@ -1,0 +1,46 @@
+const { execa } = require('execa');
+const { resolve, join } = require('path');
+const { existsSync } = require('fs');
+
+const ghcupDir = resolve(__dirname);
+const ghcupBin = join(__dirname, '.ghcup/bin/ghcup');
+
+const emsdk_mapping = {
+  "9.12.1": "3.1.74"
+}
+
+async function run(component, args) {
+  const ghcupBinDir = join(__dirname, '.ghcup/bin/');
+  const bin = join(ghcupBinDir, component);
+  if (!existsSync(bin)) {
+    console.error(`${component} not installed, use ghcup-npm install ${component} <version> first`);
+    process.exit(1);
+  }
+
+  await execa(bin, args, { stdio: 'inherit', env: { PATH: `${ghcupBinDir}:${process.env.PATH}` } }).then(({ stdout }) => console.log(stdout));
+}
+
+async function install(component, version) {
+  console.log(`Installing ${component} ${version} using ghcup at ${ghcupDir}`);
+
+  if (component == 'ghc') {
+    const emsdk_version = emsdk_mapping[version];
+    if (!emsdk_version) {
+      console.error(`Unsupported GHC version: ${version}`);
+      process.exit(1);
+    }
+
+    console.log(`Activating Emscripten SDK ${emsdk_version}`);
+    await execa('emsdk', ['install', emsdk_version], { stdio: 'inherit' }).then(({ stdout }) => console.log(stdout));
+    await execa('emsdk', ['activate', emsdk_version], { stdio: 'inherit' }).then(({ stdout }) => console.log(stdout));
+
+    console.log(`Installing ${component} ${version}`);
+    await execa('emconfigure', [ghcupBin, 'install', component, '--set', "javascript-unknown-ghcjs-" + version], { stdio: 'inherit', env: { GHCUP_INSTALL_BASE_PREFIX: ghcupDir } }).then(({ stdout }) => console.log(stdout));
+  }
+  else {
+    console.log(`Installing ${component} ${version}`);    
+    await execa(ghcupBin, ['install', component, version], { stdio: 'inherit', env: { GHCUP_INSTALL_BASE_PREFIX: ghcupDir } }).then(({ stdout }) => console.log(stdout));
+  }
+}
+
+module.exports = { install, run };

--- a/index.js
+++ b/index.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+const { program } = require('commander');
+const { version } = require('./package.json');
+const { install, run } = require('./ghcup');
+
+program
+  .name('ghcup-npm')
+  .description('An NPM wrapper for managing GHC, Cabal, and Stack via ghcup')
+  .version(version);
+
+program
+  .command('install <component> [version]')
+  .description('Install & set a GHC, Cabal, or Stack version')
+  .action(install);
+
+program
+  .command('run <command> [args...]')
+  .description('Run installed command (e.g., ghc, cabal, stack)')
+  .allowUnknownOption(true)
+  .action(run);
+
+program.showHelpAfterError();
+program.parse(process.argv);

--- a/install-ghcup.js
+++ b/install-ghcup.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+const { execa } = require('execa');
+const { resolve, join } = require('path');
+const { existsSync, mkdirSync, writeFileSync, chmodSync } = require('fs');
+
+const GHCUP_INSTALL_SCRIPT_URL = 'https://get-ghcup.haskell.org';
+
+async function installGhcup() {
+  const ghcupDir = resolve(__dirname);
+  if (!existsSync(ghcupDir)) {
+    mkdirSync(ghcupDir, { recursive: true });
+  }
+
+  const installScript = join(ghcupDir, 'install-ghcup.sh');
+  const scriptResponse = await execa('curl', ['-sSL', GHCUP_INSTALL_SCRIPT_URL], {
+    stdio: 'pipe',
+  });
+
+  writeFileSync(installScript, scriptResponse.stdout);
+  chmodSync(installScript, 0o755);
+
+  console.log('Installing ghcup...');
+  await execa(installScript, [], {
+    stdio: 'inherit',
+    env: {
+    GHCUP_INSTALL_BASE_PREFIX: ghcupDir,
+    BOOTSTRAP_HASKELL_NONINTERACTIVE: '1',
+    BOOTSTRAP_HASKELL_MINIMAL: '1',
+    },
+  }).then(({ stdout }) => console.log(stdout));
+
+  await execa(join(ghcupDir, '.ghcup/bin/ghcup'), ['config', 'add-release-channel', 'cross'], {
+    stdio: 'inherit',
+    env: {
+      GHCUP_INSTALL_BASE_PREFIX: ghcupDir
+    }
+  }).then(({ stdout }) => console.log(stdout));
+
+  console.log(`ghcup installed locally at ${ghcupDir}`);
+}
+
+installGhcup();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@haskell-org/ghcup-npm",
+  "version": "0.1.0",
+  "description": "NPM wrapper for ghcup",
+  "bin": "index.js",
+  "main": "ghcup.js",
+  "scripts": {
+    "postinstall": "node install-ghcup.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Swordlash/ghcup-npm.git"
+  },
+  "keywords": [
+    "ghc",
+    "haskell",
+    "ghcup",
+    "installer"
+  ],
+  "author": "Mateusz Goślinowski",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/Swordlash/ghcup-npm/issues"
+  },
+  "homepage": "https://github.com/Swordlash/ghcup-npm#readme",
+  "dependencies": {
+    "commander": "^13.0.0",
+    "execa": "^9.5.2"
+  }
+}


### PR DESCRIPTION
Implements a ghcup wrapper that installs `ghcup` in the node_modules subdir and allows to install tools and run commands through it. Assumes `emscripten` is installed and in PATH.